### PR TITLE
Makefile rework, new gitignore and improvements in github workflows

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -22,16 +22,13 @@ jobs:
           python-version: '3.x'
 
       - name: Setup build environment 
-        run: |
-          python -m pip install --upgrade build twine
+        run: python -m pip install --upgrade build twine
   
       - name: Build source and wheel distributions
-        run: |
-          python -m build
-          twine check --strict dist/*
+        run: make build
   
       - name: Publish to PyPi
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{secrets.PYPI_TOKEN}}

--- a/.github/workflows/pythonpublish_manual.yml
+++ b/.github/workflows/pythonpublish_manual.yml
@@ -21,16 +21,13 @@ jobs:
           python-version: '3.x'
 
       - name: Setup build environment 
-        run: |
-          python -m pip install --upgrade build twine
+        run: python -m pip install --upgrade build twine
 
       - name: Build source and wheel distributions
-        run: |
-          python -m build
-          twine check --strict dist/*
+        run: make build
 
       - name: Publish to PyPi
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload --verbose dist/*
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{secrets.PYPI_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,160 @@
-/.coverage
-/.eggs
-/.idea
-/.project
-/.pydevproject
-/htmlcov
-/kafe2.egg-info
-/examples/*/fit.png
-/examples/*/fit_?.png
-/examples/*/results
-/build
-/dist
-*.ipynb_checkpoints
-*.mypy_cache
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ SHELL := /bin/bash
 .SILENT: clean
 .IGNORE: clean
 
-build:	clean
+# build the package from the source
+build:
 	python -m build
+	twine check --strict dist/*
 
 clean:
 	rm -rf build/
@@ -13,15 +15,15 @@ clean:
 	rm -rf kafe2.egg-info/
 	rm -rf venv/
 	rm -rf `find . -type d -name __pycache__`
-	#cd docs && $(MAKE) clean
+	cd doc && $(MAKE) clean
 
-upload: build
-	twine upload dist/*
-
-venv:	build #docs
+# create a development environment
+devenv:	build 
 	python -m venv venv/
-	. venv/bin/activate; pip install dist/kafe2*.tar.gz
-	. venv/bin/activate; pip install ptpython
+	. venv/bin/activate; pip install -e .[dev]
 
-#docs:	build
-	#cd docs && $(MAKE) html
+docs:	build devenv
+	. venv/bin/activate; cd doc && $(MAKE) html 
+
+publish: build docs
+	twine upload ./dist/*


### PR DESCRIPTION
### Makefile:

The following changes were made to the Makefile

- added strict checking by twine after the build was done
- added a devenv (development environment) target to set up a venv for the development purpose
- build the documentation from within the makefile

### .gitignore

The .gititnore for this repository was replaced by the [template provided from github](https://github.com/github/gitignore/blob/main/Python.gitignore)

### workflows

The workflows now call the makefile directly. Furthermore the pypa-publish action will be used instead of calling `twine` within the environment manually