### PR TITLE
Integrated pytest test suite into pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-source = kafe2
-omit = kafe2/test/*
-command_line= -m unittest discover -v -s kafe2/test -p "*.py"
-

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip build twine
           pip install -e .[dev]
       - name: Test with pytest
         run: make test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip build
           pip install -e .[dev]
       - name: Test with pytest
         run: make test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,8 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest iminuit
+          pip install -e .[dev]
       - name: Test with pytest
-        run: |
-          pytest
+        run: make test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip build twine
-          pip install -e .[dev]
+          pip install .[dev]
       - name: Test with pytest
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# pytest output files
+test-*.yml
+
 # Translations
 *.mo
 *.pot

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ coverage.xml
 .pytest_cache/
 cover/
 
-# pytest output files
+# files generated during test to check the write to and load from file feature including kafe2go
 test-*.yml
 
 # Translations

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clean:
 	rm -rf venv/
 	rm -rf `find . -type d -name __pycache__`
 	cd doc && $(MAKE) clean
+	rm -f test-*.yml
 
 # create a development environment
 devenv:	build 
@@ -27,3 +28,6 @@ docs:	build devenv
 
 publish: build docs
 	twine upload ./dist/*
+
+test: build
+	pytest

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,4 @@ publish: build docs
 
 test: build
 	pytest
+	coverage run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,6 @@ kafe2go = "kafe2.fit.tools.kafe2go:kafe2go"
 [tool.setuptools.package-data]
 kafe2 = ["config/*.conf", "config/*.yaml", "config/*.yml", "fit/tools/kafe2go"]
 
+[tool.pytest.ini_options]
+testpaths = "kafe2/test"
+python_files = "test*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,14 @@ kafe2 = ["config/*.conf", "config/*.yaml", "config/*.yml", "fit/tools/kafe2go"]
 [tool.pytest.ini_options]
 testpaths = "kafe2/test"
 python_files = "test*.py"
+
+[tool.coverage.run]
+source = [
+	"kafe2",
+]
+omit = [
+	"kafe2/test/*",
+]
+command_line= '-m unittest discover -v -s kafe2/test -p "*.py"'
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 	{ name="Johannes Gäßler", email="johannes.gaessler@cern.ch" },
 	{ name="Cedric Verstege", email="cedric.verstege@cern.ch" },
 	{ name="Günter Quast", email="G.Quast@kit.edu" },
+	{ name="Michael Hohenstein", email="michael@hohenste.in" },
 ]
 readme = "README.rst"
 requires-python= ">=3.6"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-testpaths=kafe2/test
-python_files=test*.py


### PR DESCRIPTION
The pytest test suite has been integrated into the pyproject.toml file. The following changes were made:

- The pytest.ini file was completely integrated into pyproject.toml
- The .coveragery file was completely integrated into the pyroject.toml
- the output files of a pytest run were added to the .gitignore
- a target to execute the tests and run coverage was added to the Makefile
- The github workflow to run the pytest test suite was restructured.

As the following [workflow run](https://github.com/MitchiLaser/kafe2/actions/runs/5831975152) shows: The pytest workflows run without causing issues.

Furthermore I took the opportunity to add myself to the list of maintainers for this project.