### PR TITLE
added linting as pre-commit hook to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /bin/bash
 
 .SILENT: build clean devenv docs publish test lint
 .IGNORE: clean
+.ONESHELL:
 
 BLUE:=\033[0;34m
 NC:=\033[0m # No Color
@@ -14,8 +15,8 @@ DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # build the package from the source
 build: devenv
-	. venv/bin/activate; \
-		python -m build; \
+	. venv/bin/activate;
+		python -m build;
 		twine check --strict dist/*
 
 clean:
@@ -28,22 +29,36 @@ clean:
 	rm -f test-*.yml
 
 devenv:
-	if [ ! -d "$(DIR)/venv" ]; then \
-		echo "Creating venv"; \
-		python -m venv venv/; \
+	if [ ! -d "$(DIR)/venv" ]; then
+		echo "Creating venv";
+		python -m venv venv/;
 	fi
-	@if ! venv/bin/python -c "import kafe2" 2>/dev/null; then \
-		echo "Installing kafe2 in editable mode"; \
-		. venv/bin/activate; \
-		pip install --upgrade -e .[dev]; \
+	@if ! venv/bin/python -c "import kafe2" 2>/dev/null; then
+		echo "Installing kafe2 in editable mode";
+		. venv/bin/activate;
+		pip install --upgrade -e .[dev];
+	fi
+	if [ ! -f "$(DIR)/.git/hooks/pre-commit" ]; then
+		echo "Creating pre-commit hook";
+		cat <<'EOF' > $(DIR)/.git/hooks/pre-commit
+		#!/bin/bash
+		if make lint; then
+			echo "Linting passed."
+			exit 0
+		else
+			echo "Linting failed. Aborting commit."
+			exit 1
+		fi
+		EOF
+		chmod +x $(DIR)/.git/hooks/pre-commit
 	fi
 
 docs:	devenv
 	echo "Generating Docs"
-	. venv/bin/activate; \
-		cd doc; \
-		$(MAKE) html; \
-		$(MAKE) latex;
+	. venv/bin/activate;
+		cd doc;
+		$(MAKE) html;
+		$(MAKE) late
 
 publish: build
 	echo "uploading build to PyPI"
@@ -51,15 +66,15 @@ publish: build
 
 test: devenv
 	echo "Running Pytest and Coverage"
-	. venv/bin/activate; \
-		pytest; \
+	. venv/bin/activate;
+		pytest;
 		coverage run
 
 lint: devenv
-	. venv/bin/activate; \
-		echo -e "$(BLUE)${BOLD}ISORT${NC}$(NORM)"; \
-		isort --check --diff ./kafe2; \
-		echo -e "$(BLUE)${BOLD}BLACK${NC}$(NORM)"; \
-		black --check --diff ./kafe2; \
-		echo -e "$(BLUE)${BOLD}FLAKE8${NC}$(NORM)"; \
+	. venv/bin/activate;
+		echo -e "$(BLUE)${BOLD}ISORT${NC}$(NORM)";
+		isort --check --diff ./kafe2;
+		echo -e "$(BLUE)${BOLD}BLACK${NC}$(NORM)";
+		black --check --diff ./kafe2;
+		echo -e "$(BLUE)${BOLD}FLAKE8${NC}$(NORM)";
 		flake8 --config .flake8 ./kafe2;


### PR DESCRIPTION
This pull-request contains two changes:

1. There were some missing raw-string and empty lines so the linters were complaining.
2. After reformatting the files, the linter was added as a pre-commit hook which will automatically be installed from the makefile when setting up the development environment: `make devenv`. the Makefile was reformatted using the `.ONESHELL` to remove all the backslashes for multi-line commands.

With this hook, the linters are called on every `git commit ...`