### PR TITLE
pyproject: change license to SPDX expression

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.rst"
 requires-python= ">=3.6"
 keywords = ["kafe2", "kit", "karlsruhe", "data", "analysis", "lab", "laboratory", "practical courses", "education", "university", "students", "physics", "fitting", "minimization", "minimisation", "regression", "parametric", "parameter", "estimation", "optimization", "optimisation"]
 
-license = {text = "GPL3"}
+license = "GPL-3.0-or-later"
 classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Education",
@@ -27,7 +27,6 @@ classifiers = [
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Visualization",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Recent changes in the pyproject.toml specification:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
Changing the license classifier to an SPDX license expression removed warnings during the build process. This needs to be fixed by 2026-Feb-18 or the build are going to fail.